### PR TITLE
Kafka Tiered Storage changes (consumer isolation.level)

### DIFF
--- a/cmd/metadb/main.go
+++ b/cmd/metadb/main.go
@@ -150,6 +150,7 @@ func run() error {
 	_ = logSourceFlag(cmdStart, &serverOpt.LogSource)
 	//_ = noTLSFlag(cmdStart, &serverOpt.NoTLS)
 	_ = memoryLimitFlag(cmdStart, &serverOpt.MemoryLimit)
+	_ = readUncommittedFlag(cmdStart, &serverOpt.ReadUncommitted)
 
 	var cmdStop = &cobra.Command{
 		Use: "stop",
@@ -319,6 +320,7 @@ func help(cmd *cobra.Command, commandLine []string) {
 			noKafkaCommitFlag(nil, nil) +
 			logSourceFlag(nil, nil) +
 			memoryLimitFlag(nil, nil) +
+			readUncommittedFlag(nil, nil) +
 			"")
 	case "stop":
 		fmt.Printf("" +
@@ -552,6 +554,15 @@ func memoryLimitFlag(cmd *cobra.Command, memoryLimit *float64) string {
 	return "" +
 		"      --memlimit <m>          - Approximate limit on memory usage in GiB\n" +
 		"                                (default: 1.0)\n"
+}
+
+func readUncommittedFlag(cmd *cobra.Command, readUncommitted *bool) string {
+	if cmd != nil {
+		cmd.Flags().BoolVar(readUncommitted, "readuncommitted", false, "")
+	}
+	return "" +
+		"      --readuncommitted      - Set the read_uncommitted isolation level for Kafka consumers.\n" +
+		"							    Requirement for Tiered Storage\n"
 }
 
 func setupLog(logfile, csvlogfile string, debug bool, trace bool) (*os.File, *os.File, error) {

--- a/cmd/metadb/option/option.go
+++ b/cmd/metadb/option/option.go
@@ -20,18 +20,19 @@ type Upgrade struct {
 
 type Server struct {
 	Global
-	Debug         bool
-	Trace         bool
-	Datadir       string
-	NoKafkaCommit bool
-	LogSource     string
-	Listen        string
-	Port          string
-	TLSCert       string
-	TLSKey        string
-	NoTLS         bool
-	RewriteJSON   bool
-	MemoryLimit   float64
+	Debug           bool
+	Trace           bool
+	Datadir         string
+	NoKafkaCommit   bool
+	LogSource       string
+	Listen          string
+	Port            string
+	TLSCert         string
+	TLSKey          string
+	NoTLS           bool
+	RewriteJSON     bool
+	MemoryLimit     float64
+	ReadUncommitted bool
 }
 
 type Stop struct {

--- a/cmd/metadb/server/poll.go
+++ b/cmd/metadb/server/poll.go
@@ -235,6 +235,10 @@ func pollLoop(ctx context.Context, cat *catalog.Catalog, spr *sproc) error {
 		"partition.assignment.strategy": "roundrobin",
 		"security.protocol":             spr.source.Security,
 	}
+	// Set "read_uncommitted" isolation level for Tiered Storage
+	if spr.svr.opt.ReadUncommitted {
+		config.SetKey("isolation.level", "read_uncommitted")
+	}
 	// During normal operation, we run single-threaded to give priority to user queries.
 	// During a sync process, we enable concurrency.
 	// This could be made configurable.

--- a/doc/serveradmin.adoc
+++ b/doc/serveradmin.adoc
@@ -530,3 +530,18 @@ always setting `addschemaprefix` in data source configurations and avoiding
 names with those prefixes when creating a new schema.
 
 4. Database views should not be created in the database.
+
+=== Kafka Tiered Storage
+
+For reading logs from Kafka Tiered Storage, there is a requirement to create 
+consumers with the 'read_uncommitted' isolation level. The "confluent-kafka-go" 
+client defaults to "isolation.level": "read_committed" which enables 
+transactional reads, this creates a bottleneck when fetching from the start 
+of the topic in tiered storage and is not a valid use-case as transactions 
+are not long lived as far as the earliest offset. To change this config
+Metadb has flag `--readuncommitted` for `start` command:
+
+[source,bash]
+----
+metadb start -D data -l metadb.log --readuncommitted true
+----


### PR DESCRIPTION
These changes are required for the proper functioning of Kafka Tiered Storage (setting read_uncommitted isolation level for creating consumers): 
- Added flag "readuncommitted"
- Consumer creation: set "isolation.level" to "read_uncommitted" when "readuncommitted" flag value is "true"
- Added doc about Tiered Storage