### PR TITLE
Add snapshot completed status

### DIFF
--- a/cmd/internal/status/status.go
+++ b/cmd/internal/status/status.go
@@ -11,6 +11,7 @@ const (
 	WaitingStatus
 	StartingStatus
 	ActiveStatus
+	CompletedStatus
 	ErrorStatus
 )
 
@@ -41,6 +42,8 @@ func (st *Status) GetString() string {
 		return "starting"
 	case ActiveStatus:
 		return "active"
+	case CompletedStatus:
+		return "completed"
 	case ErrorStatus:
 		return "error"
 	default:
@@ -62,6 +65,10 @@ func (st *Status) Starting() {
 
 func (st *Status) Active() {
 	st.set(ActiveStatus)
+}
+
+func (st *Status) Completed() {
+	st.set(CompletedStatus)
 }
 
 func (st *Status) Error() {

--- a/cmd/metadb/server/poll.go
+++ b/cmd/metadb/server/poll.go
@@ -364,6 +364,7 @@ func processStream(thread int, consumer *kafka.Consumer, ctx context.Context, ca
 			msg := fmt.Sprintf("source %q snapshot complete (deadline exceeded); consider running \"metadb endsync\"",
 				spr.source.Name)
 			if dedup.Insert(msg) {
+				spr.databases[0].Status.Completed()
 				log.Info("%s", msg)
 			}
 			cat.ResetLastSnapshotRecord() // Sync timer.


### PR DESCRIPTION
Based on the discussion in the [notifier PR](https://github.com/metadb-project/metadb/pull/74), we added a snapshot completed status that is obtained from the [list()](https://github.com/metadb-project/metadb/blob/main/cmd/metadb/libpq/libpq.go#L470) function:
- Added Completed status
- Set status to Completed when snapshot ends